### PR TITLE
Update Japan_events_new.txt

### DIFF
--- a/events/Japan_events_new.txt
+++ b/events/Japan_events_new.txt
@@ -139,6 +139,9 @@ country_event = { #Black Monday Across the Colonies
 	option = { #
 		name = japan_new_event.6.a
 		ai_chance = { base = 100 }
+		add_ideas = {
+		JAP_black_monday_0
+		}
 		TAI = {
 		country_event = taiwan.1
 		country_event = taiwan.5
@@ -279,6 +282,10 @@ country_event = { #1936 Elections
 		remove_all_ministers = yes
 		add_ideas = {
 		JAP_Kokkai_hog_ade
+		}
+		country_event = {
+		id = japan_new_event.10
+		days = 7
 		}
 	}
 }
@@ -754,6 +761,10 @@ country_event = { #Army Counter Coup
 				expire = "1965.1.1"
 				ideology = junta_subtype
 			}
+		country_event = {
+		id = japan_new_event.17
+		days = 7
+		}
 	}
 }
 
@@ -769,13 +780,14 @@ country_event = { #Japanese Civil War
 		JAP = {
 		dismantle_faction = yes
 		release = KOR
-		end_puppet = TWI
 		end_puppet = TAI
+		}
 		TAI = {
 		country_event = taiwan.18
 		}
-		}
-		
+		FNG = {
+					transfer_state = 745
+				}
 		every_state = {
 					limit = {
 						is_core_of = "JAP"


### PR DESCRIPTION
Fixes: Japan didn't actually get black monday before. Deadlock gets next event for Yakuza. Army coup gets next event of revolution. FNG get's port arthur in civil war.